### PR TITLE
Decoding JWT on login

### DIFF
--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -3,6 +3,8 @@ import { useRef, useState, useContext } from "react";
 import { useNavigate } from "react-router-dom";
 import SessionContext from "../context/SessionProvider";
 import { useMutation } from "@tanstack/react-query";
+import useJWT from "../hooks/useJWT";
+import { TSession } from "../types";
 
 type LoginCredentials = {
   email: string;
@@ -49,12 +51,14 @@ const LoginForm: React.FC = () => {
       }
       const results = await response.json();
       localStorage.setItem("accessToken", results.Token);
-      localStorage.setItem("username", "rkazirut")
-      //@ts-expect-error
-      setSession((prevState) => ({
+      const JWT = useJWT(results.Token);
+      localStorage.setItem("username", JWT.Username);
+      localStorage.setItem("accountUUID", JWT.AccountUUID);
+      setSession((prevState: TSession) => ({
         ...prevState,
         [session.accessToken]: results.Token,
-        [session.username]: "rkazirut"
+        [session.username]: JWT.Username,
+        [session.accountUUID]: JWT.AccountUUID,
       }));
       navigate("/home");
     } catch (error) {

--- a/src/context/SessionProvider.tsx
+++ b/src/context/SessionProvider.tsx
@@ -1,21 +1,22 @@
 // @ts-nocheck
-import { createContext, useState} from "react";
+import { createContext, useState } from "react";
 import { TSession } from "../types";
 
-const SessionContext = createContext({})
-export const SessionProvider = ({children}) => {
-    const [session, setSession] = useState<TSession>({
-      accessToken: localStorage.getItem('accessToken'),
-      username: localStorage.getItem('username')
+const SessionContext = createContext({});
+export const SessionProvider = ({ children }) => {
+  const [session, setSession] = useState<TSession>({
+    accessToken: localStorage.getItem("accessToken"),
+    username: localStorage.getItem("username"),
+    accountUUID: localStorage.getItem("accountUUID"),
     //   refreshToken: localStorage.getItem('refreshToken')
     // email: null
-    })
+  });
 
   return (
-    <SessionContext.Provider value={{session, setSession}}>
-        {children}
+    <SessionContext.Provider value={{ session, setSession }}>
+      {children}
     </SessionContext.Provider>
-  )
-}
+  );
+};
 
 export default SessionContext;

--- a/src/hooks/useJWT.tsx
+++ b/src/hooks/useJWT.tsx
@@ -1,0 +1,13 @@
+const useJWT = (token: string) => {
+  const base64Url = token.split(".")[1];
+  const base64 = base64Url.replace(/-/g, "+").replace(/_/g, "/");
+  const jsonPayload = decodeURIComponent(
+    atob(base64)
+      .split("")
+      .map((c) => "%" + ("00" + c.charCodeAt(0).toString(16)).slice(-2))
+      .join(""),
+  );
+  return JSON.parse(jsonPayload);
+};
+
+export default useJWT;

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -17,4 +17,6 @@ export type TContent = {
 
 export type TSession = {
   accessToken: string;
-}
+  username: string;
+  accountUUID: string;
+};


### PR DESCRIPTION
Create a custom hook to decode JWT (useJWT)

When JWT is returned, the front-end will call useJWT to decode the JWT and create 3 entries to local storage:

- accessToken
- username
- accountUUID

accessToken = encoded JWT
username = Username value from JWT payload
accountUUID = AccountUUID value from JWT payload

Also fixed a ts error, which allowed for the removal of a ts-expect-error in LoginForm file.