### PR TITLE
bugfix/loginForm

### DIFF
--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -49,18 +49,20 @@ const LoginForm: React.FC = () => {
         setDisabled(false);
         throw new Error(`${response.status}`);
       }
-      const results = await response.json();
-      localStorage.setItem("accessToken", results.Token);
-      const JWT = useJWT(results.Token);
-      localStorage.setItem("username", JWT.Username);
-      localStorage.setItem("accountUUID", JWT.AccountUUID);
-      setSession((prevState: TSession) => ({
-        ...prevState,
-        [session.accessToken]: results.Token,
-        [session.username]: JWT.Username,
-        [session.accountUUID]: JWT.AccountUUID,
-      }));
-      navigate("/");
+      if (response.ok) {
+        const results = await response.json();
+        localStorage.setItem("accessToken", results.Token);
+        const JWT = useJWT(results.Token);
+        localStorage.setItem("username", JWT.Username);
+        localStorage.setItem("accountUUID", JWT.AccountUUID);
+        setSession((prevState: TSession) => ({
+          ...prevState,
+          accessToken: results.Token,
+          username: JWT.Username,
+          accountUUID: JWT.AccountUUID,
+        }));
+        navigate("/");
+      }
     } catch (error) {
       setError("There was an error");
       console.error(error);


### PR DESCRIPTION
## Login Form Fix

- Updated setSession hook

### Explanation

#### Bug
After successful login, the user was not navigated to the Home page.

#### Solution
The application router has an Outlet component that checks for Session context to verify if the user is logged in.  If a user is not logged in and they attempt to navigate to a protected route, the Outlet will navigate them back to the login page.

Upon a successful POST from the Login form, the Session context should update with the values from the decoded JWT.  The setSession hook was not written correctly, thus the Session context was not updating upon login.  Then, when the router would attempt to navigate to the Home page after the successful login, the Outlet would return the user to the login page.